### PR TITLE
Use setuptools-scm to derive version from tag.

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -35,6 +35,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -62,6 +64,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       - name: Build sdist
         run: pipx run build --sdist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=64", "wheel", "numpy>=2.0.0"]
+requires = ["setuptools>=64", "setuptools-scm>=8", "wheel", "numpy>=2.0.0"]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ astar_module = Extension(
 # Define package metadata
 setup(
     name='pyastar2d',
-    version='1.1.1',
+    use_scm_version=True,
     author='Hendrik Weideman',
     author_email='hjweide@gmail.com',
     description='A simple implementation of the A* algorithm for path-finding on a two-dimensional grid.',


### PR DESCRIPTION
  - Replace hardcoded `version='1.1.1'` in setup.py with `use_scm_version=True`
  - Add `setuptools-scm>=8` as a build dependency in pyproject.toml
  - Add `fetch-depth: 0` to both checkout steps in CI so git tags are available at build time