### PR TITLE
Restore numpy>1.x compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 imageio
-numpy>=2.0.0
+numpy>=1.21

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,8 @@ astar_module = Extension(
     ],
     define_macros=[
         ('Py_LIMITED_API', '0x03090000'),
-        ('NPY_NO_DEPRECATED_API', 'NPY_2_0_API_VERSION'),
-        ('NPY_TARGET_VERSION', 'NPY_2_0_API_VERSION'),
+        ('NPY_NO_DEPRECATED_API', 'NPY_1_21_API_VERSION'),
+        ('NPY_TARGET_VERSION', 'NPY_1_21_API_VERSION'),
     ],
     py_limited_api=True,
     include_dirs=[


### PR DESCRIPTION
Motivation
---
Proposal to partially revert the changes introduced in #49 in order to keep numpy 1.x compatibility.

My understanding of the error described in #49 is that the wheel was built with numpy 1.x, which is not forward-compatible with numpy 2.x. 
But as long as  the correct version is set with this option in `pyproject.toml`
```toml
[build-system]
requires = ["setuptools>=64", "wheel", "numpy>=2.0.0"]
```
we should be able to produce wheels that are backwards-compatible with 1.x. AFAIK, this is the standard approach to maintain compatibility (e.g. in [SciPy's pyproject.toml](https://github.com/scipy/scipy/blob/v1.15.0/pyproject.toml))

Changes
---
Revert `requirements.txt` and `NPY` macros to version 1.21 (which should be the minimum numpy version for python 3.9)

Notes
--- 
I've tested these changes by building a linux wheel with cibuildwheel and running it succesfully in two different clean environments with numpy>=2.0 and numpy<2.0 respectively.
